### PR TITLE
fix: ReferenceError in safari

### DIFF
--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -1,1 +1,1 @@
-(function(){Object.keys(sdsl).forEach(function(key){window[key]=sdsl[key]});})();
+(function(){window.addEventListener('load',function(){Object.keys(sdsl).forEach(function(key){window[key]=sdsl[key]});})})();


### PR DESCRIPTION
> Safari Version 16.2 (18614.3.7.1.5), macOS Ventura 13.1

when you load [https://js-sdsl.org/#/start/introduction](https://js-sdsl.org/#/start/introduction), you will get

```
ReferenceError: Can't find variable: sdsl
```

and when you click the `Run it` button, you will see the same message.
